### PR TITLE
fixed URL for Laravel user response

### DIFF
--- a/src/hooks.server.ts
+++ b/src/hooks.server.ts
@@ -3,7 +3,7 @@ import { redirect, type Handle } from '@sveltejs/kit';
 
 export const handle: Handle = async ({ event, resolve }) => {
 	// Verify we are authenticated
-	const responseFromServer = await authClient('/user', {
+	const responseFromServer = await authClient('/api/user', {
 		method: 'get',
 		headers: {
 			Referer: event.url.host,

--- a/src/routes/(auth)/login/+page.server.ts
+++ b/src/routes/(auth)/login/+page.server.ts
@@ -46,7 +46,7 @@ export const actions: Actions = {
 
 		headersCookies = loginResponse?.headers['set-cookie'] ?? [];
 		headerCookies = cookie.parse(headersCookies.join(';'));
-		const responseFromServer: AxiosResponse<User> | void = await authClient('/user', {
+		const responseFromServer: AxiosResponse<User> | void = await authClient('/api/user', {
 			method: 'get',
 			headers: {
 				Referer: url.host,


### PR DESCRIPTION
The URL by default is in the API route file in Laravel and not a Web route.

Fixes the below issue 

https://github.com/lindgr3n/breeze-sveltekit/issues/7